### PR TITLE
10x speedup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@ redis
 fastapi
 bmt
 jsonpickle
+pyinstrument
+orjson
 reasoner_pydantic
 uvicorn

--- a/src/keymaster.py
+++ b/src/keymaster.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 
 def create_pq(record):
     # Given an edge json record, create a string that represents the predicate and qualifiers
@@ -13,7 +13,7 @@ def create_pq(record):
         for propname, propval in record.items():
             if propname.endswith("_qualifier"):
                 pq[propname] = propval
-    return json.dumps(pq, sort_keys=True)
+    return orjson.dumps(pq, sort_keys=True)
 
 def create_trapi_pq(trapi_edge):
     # Given a trapi edge, create a string that represents the predicate and qualifiers


### PR DESCRIPTION
Rather than returning a reasoner pydantic response, we're just going to construct the json and send it back.  This gets us from about 11 seconds to 1.

There is also a smaller but noticable speedup from using orjson (and ORJSONResponse) instead of json (and JSONResponse).